### PR TITLE
guides were being searched by internal name rather than by title as displayed

### DIFF
--- a/src/components/GuidesIndex.vue
+++ b/src/components/GuidesIndex.vue
@@ -69,7 +69,9 @@ export default class GuidesIndex extends Vue {
 		if (this.search === ``) {
 			return this.guides;
 		} else {
-			return this.guides.filter(g => g.name.includes(this.search));
+			console.log(`guides including ${this.search}:`);
+			console.log(this.guides.filter(g => g.title.includes(this.search)));
+			return this.guides.filter(g => g.title.includes(this.search));
 		}
 	}
 


### PR DESCRIPTION
hotfix