### PR TITLE
move tbl style fron entitydisplay to global; change snippets to blue

### DIFF
--- a/src/components/cmp/EntityInfo.vue
+++ b/src/components/cmp/EntityInfo.vue
@@ -257,35 +257,6 @@ export default class EntityInfo extends Vue {
 	.cat-display-tbl {
 		min-width: 50%;
 		max-width: 90%;
-
-		thead {
-			text-align: center;
-			border-bottom: 1px solid $balcora-highlight-gray;
-		}
-
-		tbody {
-			border-left: 1px solid $balcora-highlight-gray;
-			border-right: 1px solid $balcora-highlight-gray;
-
-			tr {
-				td {
-					padding: 5px 20px;
-					white-space: nowrap;
-				}
-
-				td:first-child {
-					border-right: 1px solid $balcora-highlight-gray;
-				}
-			}
-
-			tr:nth-child(even) {
-				background-color: $balcora-highlight-gray;
-
-				td:first-child {
-					border-right: 1px solid $balcora-base-gray;
-				}
-			}
-		}
 	}
 }
 </style>

--- a/src/styles/code-highlight.scss
+++ b/src/styles/code-highlight.scss
@@ -2,6 +2,10 @@
 
 @import "styles/highlight-js/monokai-sublime";
 
+code {
+	color: lighten($balcora-blue, 7%);
+}
+
 pre {
 	color: #ddd;
 	border: 1px solid #ddd;

--- a/src/styles/site.scss
+++ b/src/styles/site.scss
@@ -57,3 +57,34 @@ ul.clean-list {
 	margin: 0;
 	padding: 0;
 }
+
+table {
+	thead {
+		text-align: center;
+		border-bottom: 1px solid $balcora-highlight-gray;
+	}
+
+	tbody {
+		border-left: 1px solid $balcora-highlight-gray;
+		border-right: 1px solid $balcora-highlight-gray;
+
+		tr {
+			td {
+				padding: 5px 20px;
+				white-space: nowrap;
+			}
+
+			td:first-child {
+				border-right: 1px solid $balcora-highlight-gray;
+			}
+		}
+
+		tr:nth-child(even) {
+			background-color: $balcora-highlight-gray;
+
+			td:first-child {
+				border-right: 1px solid $balcora-base-gray;
+			}
+		}
+	}
+}


### PR DESCRIPTION
- Moved table styling from `EntityDisplay.vue` to `site.scss`, as it's pretty generic and nice
- Code snippets are now `$balcora-blue` lightened slightly instead of the default pink